### PR TITLE
Sanitize pagename for prevent URL-related errors

### DIFF
--- a/action.php
+++ b/action.php
@@ -52,6 +52,7 @@ class action_plugin_pagebuttons extends DokuWiki_Action_Plugin {
         global $conf;
         $JSINFO['plugin_pagebuttons'] = array(
             'usePrompt' => $this->getConf('usePrompt'),
+            'sepchar' => $conf['sepchar'],
             'useslash' => $conf['useslash'],
             'start' => $conf['start']
         );

--- a/script.js
+++ b/script.js
@@ -17,9 +17,21 @@ jQuery(function() {
     var usePrompt = 0;
     if(JSINFO && JSINFO['plugin_pagebuttons']){
         var usePrompt = JSINFO['plugin_pagebuttons']['usePrompt'];
+        var sepchar = JSINFO['plugin_pagebuttons']['sepchar'];
         var start = JSINFO['plugin_pagebuttons']['start'];
         var useSlash = JSINFO['plugin_pagebuttons']['useslash'];
         var urlSeparator = useSlash ? "/" : ":";
+    }
+
+    function _sanitize_pagename(name) {
+        name = name.trim()
+                   .toLowerCase()
+                   .replace(/[ ?#$&%.]+/g, sepchar)
+                   .replace(/:+/g, ":")
+                   .replace(/^[:_]+/, "")
+                   .replace(/[:_]+$/, "")
+                   .replace(/:/g, urlSeparator);
+        return name
     }
 
     jQuery('.plugin_pagebuttons_deletepage').click(function(d) {
@@ -104,7 +116,7 @@ jQuery(function() {
                         click: function () {
                             var folder = document.getElementsByName("new_folder_name")[0].value;
                             $dialog.dialog("close");
-                            var submit_url = pre_url + urlSeparator + folder + urlSeparator + start + "&do=edit";
+                            var submit_url = pre_url + urlSeparator + _sanitize_pagename(folder) + urlSeparator + start + "&do=edit";
                             window.location.href = submit_url
                         }
                     },
@@ -160,7 +172,7 @@ jQuery(function() {
                         click: function () {
                             var newpage = document.getElementsByName("new_page_name")[0].value;
                             $dialog.dialog("close");
-                            var submit_url = pre_url + urlSeparator + newpage + "&do=edit";
+                            var submit_url = pre_url + urlSeparator + _sanitize_pagename(newpage) + "&do=edit";
                             window.location.href = submit_url
                         }
                     },

--- a/script.js
+++ b/script.js
@@ -26,7 +26,7 @@ jQuery(function() {
     function _sanitize_pagename(name) {
         name = name.trim()
                    .toLowerCase()
-                   .replace(/[ ?#$&%.\[\]=+,\\]+/g, sepchar)
+                   .replace(/[ ?#$&%.\[\]=+,\\<>'"~`|]+/g, sepchar)
                    .replace(/:+/g, ":")
                    .replace(/^[:_]+/, "")
                    .replace(/[:_]+$/, "")

--- a/script.js
+++ b/script.js
@@ -26,12 +26,14 @@ jQuery(function() {
     function _sanitize_pagename(name) {
         name = name.trim()
                    .toLowerCase()
-                   .replace(/[ ?#$&%.]+/g, sepchar)
+                   .replace(/[ ?#$&%.\[\]=+,\\]+/g, sepchar)
                    .replace(/:+/g, ":")
                    .replace(/^[:_]+/, "")
                    .replace(/[:_]+$/, "")
                    .replace(/:/g, urlSeparator);
-        return name
+        
+        if (name == "") return start;
+        else return name;
     }
 
     jQuery('.plugin_pagebuttons_deletepage').click(function(d) {


### PR DESCRIPTION
- Replace some characters that take some roles in URL, including space(like ` ?#$&%.`).
- Remove prefix or suffixed `:` and invalid characters.